### PR TITLE
Fix intent flag order

### DIFF
--- a/src/lib/conversionTracking.ts
+++ b/src/lib/conversionTracking.ts
@@ -96,11 +96,11 @@ export class ConversionTracker {
 
     // Trigger personalization based on score
     if (this.engagementScore > 70 && !this.hasTriggeredHighIntent) {
-      this.triggerHighIntentExperience()
       this.hasTriggeredHighIntent = true
+      this.triggerHighIntentExperience()
     } else if (this.engagementScore > 40 && !this.hasTriggeredMediumIntent) {
-      this.triggerMediumIntentExperience()
       this.hasTriggeredMediumIntent = true
+      this.triggerMediumIntentExperience()
     }
 
     // Dispatch custom event for other components to listen


### PR DESCRIPTION
## Summary
- set high/medium intent flags before triggering experiences to avoid recursive scoring

## Testing
- `npm run lint`
- `npm test` *(fails: ReferenceError: Request is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68525df411c08330a029bca2b79c0a12